### PR TITLE
mixed content warning because of image in <noscript>

### DIFF
--- a/lib/rack/templates/async.erb
+++ b/lib/rack/templates/async.erb
@@ -25,6 +25,6 @@
 <!-- Image Tracker -->
 <noscript>
   <%# TODO set protocol (HTTP or HTTPS) based on the current protocol according to rack logic %>
-  <img src="http://<%= @options[:piwik_url] %>/piwik.php?idsite=<%= @options[:piwik_id] %>&amp;rec=1" style="border:0" alt="" />
+  <img src="//<%= @options[:piwik_url] %>/piwik.php?idsite=<%= @options[:piwik_id] %>&amp;rec=1" style="border:0" alt="" />
 </noscript>
 <!-- End Piwik -->

--- a/lib/rack/templates/sync.erb
+++ b/lib/rack/templates/sync.erb
@@ -22,6 +22,6 @@ try {
 <!-- Image Tracker -->
 <noscript>
   <%# TODO set protocol (HTTP or HTTPS) based on the current protocol according to rack logic %>
-  <img src="http://<%= @options[:piwik_url] %>/piwik.php?idsite=<%= @options[:piwik_id] %>&amp;rec=1" style="border:0" alt="" />
+  <img src="//<%= @options[:piwik_url] %>/piwik.php?idsite=<%= @options[:piwik_id] %>&amp;rec=1" style="border:0" alt="" />
 </noscript>
 <!-- End Piwik -->


### PR DESCRIPTION
Hi,

I'm maintainer of a [diaspora*](https://github.com/diaspora/diaspora) pod, which uses this gem for piwik integration.

Today I noticed, that I get a mixed content warning although all my images and ressources are embedded with https:// and all external images are proxied.

I noticed, that the <noscript> tag of piwik contains a http:// image and after I deactivated the piwik integration the mixed content warning dissappeared, so I guess [this template](https://github.com/maxwell/rack-piwik/blob/master/lib/rack/templates/sync.erb) is the reason why a warning appeared in first place.

I guess it would be best to inherit Piwik's default code with src="//url" instead of src="http://url"

Best
lub
